### PR TITLE
Fix duplicate names

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@ users_homeco:
     comment: "User Two"
     password: '$6$3mNHVelzKm0Jk5IRfDTgqMJDvkDwYbH.bxvcqIfHUC4b/wuPMIvVxdt.'
 
-  - name: user2
+  - name: user3
     comment: "User Three"
     password: '!'
 


### PR DESCRIPTION
In defaults/main.yml user2 is defined twice and there is no user3 defined.